### PR TITLE
Get rid of continue statement that was throwing error by Babel on Angular

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -240,18 +240,24 @@ export function linter(source: (view: EditorView) => readonly Diagnostic[] | Pro
 }
 
 function assignKeys(actions: readonly Action[] | undefined) {
-  let assigned: string[] = []
-  if (actions) actions: for (let {name} of actions) {
+  if (!actions) {
+    return [];
+  }
+
+  const names: string[] = actions.map(action => action.name);
+
+  return names.reduce((assigned: string[], name) => {
     for (let i = 0; i < name.length; i++) {
       let ch = name[i]
       if (/[a-zA-Z]/.test(ch) && !assigned.some(c => c.toLowerCase() == ch.toLowerCase())) {
         assigned.push(ch)
-        continue actions
+        return assigned
       }
     }
+
     assigned.push("")
-  }
-  return assigned
+    return assigned
+  }, []);
 }
 
 function renderDiagnostic(view: EditorView, diagnostic: Diagnostic, inPanel: boolean) {

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "lib": ["es6", "dom", "scripthost"],
-    "types": ["mocha"],
     "stripInternal": true,
     "noUnusedLocals": true,
     "strict": true,


### PR DESCRIPTION
Hi, after migration from `@codemirror/next` to `@codemirror/lint` I'm getting error during angular compilation:

```
ERROR in C:/my-app/node_modules/@codemirror/lint/dist/index.js
Module build failed (from C:/my-app/node_modules/@angular-devkit/build-angular/node_modules/babel-loader/lib/index.js):
TypeError: C:\my-app\node_modules\@codemirror\lint\dist\index.js: Property body expected type of array but got null
    at validate (C:\my-app\node_modules\@babel\core\node_modules\@babel\types\lib\definitions\utils.js:160:13)
    at Object.validate (C:\my-app\node_modules\@babel\core\node_modules\@babel\types\lib\definitions\utils.js:229:7)
    at validateField (C:\my-app\node_modules\@babel\core\node_modules\@babel\types\lib\validators\validate.js:24:9)
    at Object.validate (C:\my-app\node_modules\@babel\core\node_modules\@babel\types\lib\validators\validate.js:17:3)
    at NodePath._replaceWith (C:\my-app\node_modules\@babel\core\node_modules\@babel\traverse\lib\path\replacement.js:179:7)
```

After some changes I've started getting error: `SyntaxError: C:\workspaces\cluster\ui\angular\angular.server\node_modules\@codemirror\lint\dist\index.js: Unsyntactic continue (209:21)`

When I get rid of this continue and changed implementation to proposed in the PR the Angular app is compiling.
I did some unit tests for this change but the function is not `exported` so I didn't commit them.