### PR TITLE
Fixes lint issue

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -247,15 +247,17 @@ export function linter(
 
 function assignKeys(actions: readonly Action[] | undefined) {
   let assigned: string[] = []
-  if (actions) actions: for (let {name} of actions) {
-    for (let i = 0; i < name.length; i++) {
-      let ch = name[i]
-      if (/[a-zA-Z]/.test(ch) && !assigned.some(c => c.toLowerCase() == ch.toLowerCase())) {
-        assigned.push(ch)
-        continue actions
+  if (actions) { 
+    actions: for (let {name} of actions) {
+      for (let i = 0; i < name.length; i++) {
+        let ch = name[i]
+        if (/[a-zA-Z]/.test(ch) && !assigned.some(c => c.toLowerCase() == ch.toLowerCase())) {
+          assigned.push(ch)
+          continue actions
+        }
       }
+      assigned.push("")
     }
-    assigned.push("")
   }
   return assigned
 }


### PR DESCRIPTION
labeled loop causes build to break.

babel doesn't seem to understand "if statement followed by label loop" and throws the following error -

`node_modules/@codemirror/lint/dist/index.js: Property body expected type of array but got null`

The suggested PR fixes this by adding curly braces to the if statement.