### PR TITLE
Allow lint gutter hover time to be configured

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,15 +1,7 @@
 import {EditorView, ViewPlugin, Decoration, DecorationSet,
         WidgetType, ViewUpdate, Command, logException, KeyBinding} from "@codemirror/view"
-import {
-  Text,
-  StateEffect,
-  StateField,
-  Extension,
-  TransactionSpec,
-  EditorState,
-  Facet,
-  combineConfig
-} from "@codemirror/state"
+import {Text, StateEffect, StateField, Extension, TransactionSpec,
+        EditorState, Facet, combineConfig} from "@codemirror/state"
 import {hoverTooltip, Tooltip, showTooltip} from "@codemirror/tooltip"
 import {PanelConstructor, Panel, showPanel, getPanel} from "@codemirror/panel"
 import {gutter, GutterMarker} from "@codemirror/gutter"

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -47,7 +47,7 @@ export interface Action {
   apply: (view: EditorView, from: number, to: number) => void
 }
 
-export interface LintGutterConfig {
+interface LintGutterConfig {
   /// The delay before showing a tooltip when hovering over a lint gutter marker.
   hoverTime?: number
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -639,8 +639,8 @@ const enum Hover {
 function trackHoverOn(view: EditorView, marker: HTMLElement) {
   let mousemove = (event: MouseEvent) => {
     let rect = marker.getBoundingClientRect()
-    if (event.clientX > rect.left - Hover.Time && event.clientX < rect.right + Hover.Time &&
-        event.clientY > rect.top - Hover.Time && event.clientY < rect.bottom + Hover.Time)
+    if (event.clientX > rect.left - Hover.Margin && event.clientX < rect.right + Hover.Margin &&
+        event.clientY > rect.top - Hover.Margin && event.clientY < rect.bottom + Hover.Margin)
       return
     for (let target = event.target as Node | null; target; target = target.parentNode) {
       if (target.nodeType == 1 && (target as HTMLElement).classList.contains("cm-tooltip-lint"))

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -50,8 +50,6 @@ export interface Action {
 export interface LintGutterConfig {
   /// The delay before showing a tooltip when hovering over a lint gutter marker.
   hoverTime?: number
-  /// The margin within which a tooltip will continue to be shown when moving out of a lint gutter marker.
-  hoverMargin?: number
 }
 
 class SelectedDiagnostic {
@@ -647,11 +645,10 @@ const enum Hover {
 }
 
 function trackHoverOn(view: EditorView, marker: HTMLElement) {
-  let {hoverMargin} = view.state.facet(lintGutterConfig)
   let mousemove = (event: MouseEvent) => {
     let rect = marker.getBoundingClientRect()
-    if (event.clientX > rect.left - hoverMargin && event.clientX < rect.right + hoverMargin &&
-        event.clientY > rect.top - hoverMargin && event.clientY < rect.bottom + hoverMargin)
+    if (event.clientX > rect.left - Hover.Time && event.clientX < rect.right + Hover.Time &&
+        event.clientY > rect.top - Hover.Time && event.clientY < rect.bottom + Hover.Time)
       return
     for (let target = event.target as Node | null; target; target = target.parentNode) {
       if (target.nodeType == 1 && (target as HTMLElement).classList.contains("cm-tooltip-lint"))
@@ -768,7 +765,6 @@ const lintGutterConfig = Facet.define<LintGutterConfig, Required<LintGutterConfi
   combine(configs) {
     return combineConfig(configs, {
       hoverTime: Hover.Time,
-      hoverMargin: Hover.Margin,
     });
   }
 });


### PR DESCRIPTION
It would be useful to be able to configure the value used by the `lintGutter` extension for hover time (delay).

This adds a `config` parameter with boolean `hoverTime` property, defaulting to the existing constant `Hover.Time`.

---

A screen recording of a hover with `hoverTime` set to `1`:

https://user-images.githubusercontent.com/14294/155545229-0c49202c-afce-45b8-8d92-b599849bfd42.mov


