### PR TITLE
Ensure that lint gutter tooltip is displayed underneath the gutter marker

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -655,8 +655,9 @@ function trackHoverOn(view: EditorView, marker: HTMLElement) {
 
 function gutterMarkerMouseOver(view: EditorView, marker: HTMLElement, diagnostics: readonly Diagnostic[]) {
   function hovered() {
-    let line = view.visualLineAtHeight(marker.getBoundingClientRect().top + 5 - view.documentTop)
-    const linePos = view.coordsAtPos(line.from), markerRect = marker.getBoundingClientRect()
+    let markerRect = marker.getBoundingClientRect()
+    let line = view.visualLineAtHeight(markerRect.top + 5 - view.documentTop)
+    const linePos = view.coordsAtPos(line.from)
     if (linePos) {
       view.dispatch({effects: setLintGutterTooltip.of({
         pos: line.from,
@@ -664,7 +665,7 @@ function gutterMarkerMouseOver(view: EditorView, marker: HTMLElement, diagnostic
         create() {
           return {
             dom: diagnosticsTooltip(view, diagnostics),
-            offset: {x: markerRect.left - linePos.left, y: 0}
+            offset: {x: markerRect.left - linePos.left, y: markerRect.top - linePos.top}
           }
         }
       })})

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -661,6 +661,7 @@ function gutterMarkerMouseOver(view: EditorView, marker: HTMLElement, diagnostic
     if (linePos) {
       view.dispatch({effects: setLintGutterTooltip.of({
         pos: line.from,
+        end: line.to,
         above: false,
         create() {
           return {


### PR DESCRIPTION
The aim here is to ensure that a lint gutter tooltip is displayed directly underneath the gutter marker when line wrapping is enabled (where the marker is positioned in the vertical centre of the "visual line"), rather than underneath the first line.

diagnostic marker on a short line:

<img width="590" alt="image" src="https://user-images.githubusercontent.com/14294/155710230-f02f616c-2058-4a16-a47f-57d4ba4fb47f.png">

diagnostic marker on a long line:

<img width="590" alt="image" src="https://user-images.githubusercontent.com/14294/155710278-c316b52f-de88-4c17-a81c-e37a0d9c02d9.png">
