### PR TITLE
Export lintState StateField

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,6 +8,8 @@
 
 @LintSource
 
+@lintState
+
 @diagnosticCount
 
 @forceLinting

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -142,6 +142,7 @@ const togglePanel = StateEffect.define<boolean>()
 
 const movePanelSelection = StateEffect.define<SelectedDiagnostic>()
 
+/// The state field that tracks the set of active diagnostics.
 export const lintState = StateField.define<LintState>({
   create() {
     return new LintState(Decoration.none, null, null)

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -142,7 +142,7 @@ const togglePanel = StateEffect.define<boolean>()
 
 const movePanelSelection = StateEffect.define<SelectedDiagnostic>()
 
-const lintState = StateField.define<LintState>({
+export const lintState = StateField.define<LintState>({
   create() {
     return new LintState(Decoration.none, null, null)
   },


### PR DESCRIPTION
This PR exports the `lintState` StateField, which enables users to lookup the state of that field view the `view.state.field(lintState)` mechanism.

While building out the ability to provide information via tooltips, I ran into an issue with styling the tooltips that come out of the lint function. [This discussion thread](https://discuss.codemirror.net/t/cm6-merging-lint-and-hover-tooltips-over-the-same-range/3010) describes a change that enabled combining all tooltips into a single container, which ensures they don't overlap. However, there is not currently a mechanism for directly intercepting and controlling the content of a lint hover tooltip at the same time as a normal hover tooltip.

My initial approach was to create a new state field and watch the `setDiagnosticsEffect`, and then set that state field to the value of the new diagnostics. However, I found that there was a race condition between the time that a hover tooltip started and the time that the state field was updated–I was seeing the hover tooltip called before the state field update. 

<details>
<summary>Here's what that code looked like</summary>

```tsx
export const diagnosticStateField = StateField.define<
  ReadonlyArray<Diagnostic>
>({
  create: (_: EditorState) => [],

  update(value, transaction) {
    if (transaction.docChanged === true) {
      let newDiagnostics: ReadonlyArray<Diagnostic> = [];

      transaction.effects.map((effect) => {
        if (effect.is(setDiagnosticsEffect)) {
          newDiagnostics = effect.value;
        }
      });

      return newDiagnostics;
    }

    return value;
  },
});
```
</details>


After doing some additional research, I found that I could do all of the work I needed to do if I had access to the `lintState` field, via the `.field` accessor on `state`. Rather than duplicating this into its own locally-defined state field, it would be better to simply access the existing one.

Because the properties on `lintState` are read-only, it seemed safe to expose this outside of the library.