### PR TITLE
Add a diagnostics accessor

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -172,6 +172,24 @@ const lintState = StateField.define<LintState>({
                  EditorView.decorations.from(f, s => s.diagnostics)]
 })
 
+/// Returns the active lint diagnostics in the given state.
+export function activeDiagnostics(state: EditorState) {
+  const lint = state.field(lintState, false)
+
+  if (!lint) { 
+    return [];
+  }
+
+  const { diagnostics } = lint;
+  const found: Diagnostic[] = [];
+
+  diagnostics.between(0, state.doc.length, (_start, _end, {spec}) => {
+    found.push(spec.diagnostic);
+  });
+
+  return found;
+}
+
 /// Returns the number of active lint diagnostics in the given state.
 export function diagnosticCount(state: EditorState) {
   let lint = state.field(lintState, false)


### PR DESCRIPTION
Similar to the `diagnosticCount` accessor, provide an interface to get diagnostics from a given state.

**Use Case**

We want to implement and external Lint panel, similar to the `Problems` tab in VS-Code, that accumulates all linting messages accross different components. For this, we need a way to access the currently active Diagnostics in the Editor.