### PR TITLE
feat: add getDiagnostics function

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -134,6 +134,21 @@ export function setDiagnostics(state: EditorState, diagnostics: readonly Diagnos
   }
 }
 
+/// Returns all diagnostics attached to the provided state. If `from`
+/// is given, returns only the diagnostics whose range ends at or
+/// after that document position.
+export function getDiagnostics (state: EditorState, from?: number): Diagnostic[] {
+  const allDiagnostics: Diagnostic[] = []
+  const cursor = state.field(lintState).diagnostics.iter(from)
+
+  while (cursor.value !== null) {
+    allDiagnostics.push(cursor.value.spec.diagnostic)
+    cursor.next()
+  }
+
+  return allDiagnostics
+}
+
 /// The state effect that updates the set of active diagnostics. Can
 /// be useful when writing an extension that needs to track these.
 export const setDiagnosticsEffect = StateEffect.define<readonly Diagnostic[]>()


### PR DESCRIPTION
Adds a function that can be used to retrieve all diagnostics that are present in the provided state. This PR basically addresses [this discussion over on discuss.codemirror.net](https://discuss.codemirror.net/t/i-want-to-check-if-there-are-lint-errors/2171) that was originally posted for CodeMirror 5, but since this functionality doesn't exist in the v6 as well, I figured it would be great to finally have it.

## Description

What this PR does is add a new function, `getDiagnostics` that returns all diagnostics that are present within a provided state. To do so, it basically just takes the `lintState` field and iterates over the generated decorations, collecting the attached diagnostics along the way and returning them as a single array.

This can be used to attach various linters to the state and retrieve them. Users can then afterwards filter them (e.g. look at their `source` property) and do something with it. This can prove handy for example when you have one or more linters active that probe a file for problems and need to access them outside of the linter function in order to prevent double work.

## Rationale

Normally, the `action` field can be used to define some actions the user can perform to fix or improve the linter error. However, sometimes the potential actions are too many or need to be fetched on-demand. Therefore, it is handy to have a function to quickly retrieve whatever the linters have found and therefore to avoid having to check the file's contents twice.

## Example usecase

I've basically moved forward with this because I'm using the built-in linter function to create a custom spell checker (because I can't completely rely on the OS for doing the spell checking).

Said spell checker contains a ton of code to ensure we're spell-checking correctly (i.e. takes into account brackets and custom quote symbols). However, while functionally a spell checker is a linter, potential `actions` that can be taken are normally provided in a context menu and not via `actions` like other linters.

In order to avoid having to run the spellchecker twice over the text, one can use this function to retrieve all diagnostics currently attached to the state whenever the user requests a context menu, filter out anything whose `source` is my spell checker and check if there's a spelling error underneath the cursor position, and provide suggestions as applicable.

## Caveats

Currently, this simply takes all diagnostics irrespective of the originating `Facet`s, both because I'm still not comfortably proficient with the use of facets, and because normally the amount of linter errors/warnings/infos should be fairly manageable. Therefore, this PR basically rests on the range iterator being fast.

Also, one could also simply save the decorations manually in the stateField, but I felt this implementation is the least intrusive into the existing code, hence preventing potential other problems.

I tried to stick to the conventions of the repo, but please feel free to outline any potential problems with this implementation and what I can change.

Thank you for your outstanding work – CodeMirror 6 is simply amazing!