### PR TITLE
Fix apply callback running twice in diagnostic actions

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -373,7 +373,6 @@ function renderDiagnostic(view: EditorView, diagnostic: Diagnostic, inPanel: boo
         type: "button",
         class: "cm-diagnosticAction",
         onclick: click,
-        onmousedown: click,
         "aria-label": ` Action: ${name}${keyIndex < 0 ? "" : ` (access key "${keys[i]})"`}.`
       }, nameElt)
     }),


### PR DESCRIPTION
It looks like the apply handlers for lint diagnostic actions are getting run twice because it's being executed as part of the `onclick`  _and_ `onmousedown` events, which does not seem to be intentional (but please correct me if I'm wrong).

See repro here: https://replit.com/@SergeiChestakov/cm-lint-apply

And demo below:

![double-lint-action](https://user-images.githubusercontent.com/24947334/218947228-fdfee3eb-6268-4208-ae55-9b1e3b450f84.gif)
