### PR TITLE
Add `toggleLintPanel` to alternate state.

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -211,6 +211,13 @@ function diagnosticsTooltip(view: EditorView, diagnostics: readonly Diagnostic[]
   return elt("ul", {class: "cm-tooltip-lint"}, diagnostics.map(d => renderDiagnostic(view, d, false)))
 }
 
+/// Command to toggle the lint panel open/closed
+export const toggleLintPanel: Command = (view: EditorView) => {
+  let panel = getPanel(view, LintPanel.open)
+  if (panel) return closeLintPanel(view)
+  return openLintPanel(view)
+}
+
 /// Command to open and focus the lint panel.
 export const openLintPanel: Command = (view: EditorView) => {
   let field = view.state.field(lintState, false)


### PR DESCRIPTION
`openLintPanel` and `closeLintPanel` do not seem to provide any indicator of whether the lint panel is open. 

I considered trying to export some of the state fields themselves, so a consumer of the API could query, say, `getPanel(view, LintPanel.open)`, but my actual use case only requires a toggle method and the encapsulation seems simpler this way.

This may not be quite as you intend, especially with respect to returning the handled boolean, but I'm happy to shepherd it until it is appropriate. If you'd prefer I try to export some useful state instead, I'm happy to go about that.