### PR TITLE
Initialize reducer with an empty array

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -290,7 +290,7 @@ const lintPlugin = ViewPlugin.fromClass(class {
       let {state} = this.view, {sources} = state.facet(lintConfig)
       Promise.all(sources.map(source => Promise.resolve(source(this.view)))).then(
         annotations => {
-          let all = annotations.reduce((a, b) => a.concat(b))
+          let all = annotations.reduce((a, b) => a.concat(b), [])
           if (this.view.state.doc == state.doc)
             this.view.dispatch(setDiagnostics(this.view.state, all))
         },


### PR DESCRIPTION
If the `sources` array is empty for some reason (unknown but it seems to happen, as we've seen this error logged), avoid a “reduce of empty array with no initial value” error being thrown by initialising the reducer with an empty array.